### PR TITLE
Change the effect to use the deployment event subscription

### DIFF
--- a/Hex Pilots Plus/mods/Thorne the Judge/scripts/hooks.lua
+++ b/Hex Pilots Plus/mods/Thorne the Judge/scripts/hooks.lua
@@ -24,116 +24,40 @@ ANIMS.ExploSunbeam = Animation:new{
 	PosY = -55,
 	Loop = false
 }
---------------------------------------------------- UTILITY / LOCAL FUNCTIONS ---------------------------------------------------
-local function GetUser()
-	for i = 0,2 do
-		local mech = Board:GetPawn(i)
-		if mech then
-			--LOG("ability: " .. mech:GetAbility()) 
-			if mech:IsAbility("Mourningstar") then
-				--LOG("mech has the right skill!")
-				return Board:GetPawn(i)
-			end
-		end
-	end
-	return nil
-end
-
-local function IsUserPresent()
-	--LOG("[APOLLO] IsApolloPresent()")
-	for i = 0, 2 do
-		local mech = Board:GetPawn(i)
-		--LOG("i: " .. tostring(i))
-		if mech then
-			--LOG("ability: " .. mech:GetAbility()) 
-			if mech:IsAbility("Mourningstar") then
-				--LOG("mech has right skill!")
-				return true
-			else
-				--LOG("not the right skill :(")
-			end
-		else
-			--LOG("Mech doesn't exist!!")
-		end
-	end
-	return false
-end
 ----------------------------------------------- HOOKS HANDLERS -----------------------------------------------
 
-local function GetSkillEffect(p1)
+local function Hedera_Sunrise(pawnId)
+	local pawn = Board:GetPawn(pawnId)
+	local p1 = pawn:GetSpace()
 	local ret = SkillEffect()
-	local damage = SpaceDamage(Point(0,0),0)
-	damage.iFire = 1
-	damage.sAnimation = "ExploSunbeam"
 	
-	local shine = SpaceDamage(p1,0)
-	shine.sAnimation = "ExploSunrise"
-	ret:AddDamage(shine)
-	
-	ret:AddBoardShake(0.1)
-	
-	local board_size = Board:GetSize()
-	for i = 0, board_size.x - 1 do
-		for j = 0, board_size.y - 1 do
-			if Board:IsValid(Point(i,j)) and not Board:IsBuilding(Point(i,j)) then
-				if Board:IsPawnSpace(Point(i,j)) and not Board:IsPawnTeam(Point(i,j),TEAM_PLAYER) then
-					damage.loc = Point(i,j)
-					ret:AddDamage(damage)
-					ret:AddDelay(0.1)
-				end
+	if pawn and pawn:IsAbility("Mourningstar") then
+		local damage = SpaceDamage(Point(0,0),0)
+		damage.iFire = 1
+		damage.sAnimation = "ExploSunbeam"
+		
+		local shine = SpaceDamage(p1,0)
+		shine.sAnimation = "ExploSunrise"
+		ret:AddDamage(shine)
+		
+		ret:AddBoardShake(0.1)
+		
+		local pawnList = extract_table(Board:GetPawns(TEAM_ANY))
+		for i = 1, #pawnList do
+			local unit = Board:GetPawn(pawnList[i])
+			local space = unit:GetSpace()
+			if unit:GetTeam() ~= TEAM_PLAYER and Board:IsValid(space) then
+				damage.loc = space
+				ret:AddDamage(damage)
+				ret:AddDelay(0.1)
 			end
 		end
+		
+		if Board then Board:AddEffect(ret) end-- prevent possible crash when player backs out to menu
 	end
-	
-	return ret
-end
-
-local ApplyEffect = function(mission)
-	if IsUserPresent() and Board:GetTurn() < 1 then
-		local user_loc = GetUser():GetSpace()
-		Board:AddEffect(GetSkillEffect(user_loc))
-	end
-end
-
-local function DelayEffect()
-modApi:conditionalHook(
-	function()
-		if IsUserPresent() then
-			return Board:GetTurn() == 1
-		end
-		return false
-	end,
-	function()
-		ApplyEffect()
-	end
-)
 end
 
 ----------------------------------------------- HOOKS / EVENTS SUBSCRIPTION -----------------------------------------------
 
---this section detects the event that triggers instantly when End Turn is pressed (PARADOXICA)
-EXCL = {
-	"GetAmbience", 
-	"GetBonusStatus", 
-	"BaseUpdate", 
-	"UpdateMission", 
-	"GetCustomTile", 
-	"GetDamage", 
-	"GetTurnLimit", 
-	"BaseObjectives",
-	"UpdateObjectives",
-} 
-
-for i,v in pairs(Mission) do 
-	if type(v) == 'function' then 
-		local oldfn = v 
-		Mission[i] = function(...) 
-			if not list_contains(_G["EXCL"], i) then 
-				if i == "IsEnvironmentEffect" then
-					ApplyEffect()
-				end 
-			end 
-			return oldfn(...) 
-		end 
-	end 
-end
+modApi.events.onPawnLanded:subscribe(Hedera_Sunrise)
+-- the argument of this argument function is an integer (the ID of the Mech that has landed)


### PR DESCRIPTION
Caveat: This requires the updated version of deployment.lua instead of the present one (at time of submission), due to the oversight which causes it to only trigger once the first Mech (Pawn Id 0) has landed.

There is also a delay created by the skill-effect causing the Board to be in a busy state.

The only solution to this (to the best of my knowledge) would be to create a global counter that increments until all three Mechs have deployed, upon which then you choose to trigger the effect without creating a noticeable delay between Mechs landing. If you want this solution to be implemented, let me know and I will send it through.