### PR TITLE
Changed to use board/game commands to work w/ deploy

### DIFF
--- a/Hex Pilots Plus/mods/Thorne the Judge/scripts/hooks.lua
+++ b/Hex Pilots Plus/mods/Thorne the Judge/scripts/hooks.lua
@@ -24,116 +24,34 @@ ANIMS.ExploSunbeam = Animation:new{
 	PosY = -55,
 	Loop = false
 }
---------------------------------------------------- UTILITY / LOCAL FUNCTIONS ---------------------------------------------------
-local function GetUser()
-	for i = 0,2 do
-		local mech = Board:GetPawn(i)
-		if mech then
-			--LOG("ability: " .. mech:GetAbility()) 
-			if mech:IsAbility("Mourningstar") then
-				--LOG("mech has the right skill!")
-				return Board:GetPawn(i)
-			end
-		end
-	end
-	return nil
-end
-
-local function IsUserPresent()
-	--LOG("[APOLLO] IsApolloPresent()")
-	for i = 0, 2 do
-		local mech = Board:GetPawn(i)
-		--LOG("i: " .. tostring(i))
-		if mech then
-			--LOG("ability: " .. mech:GetAbility()) 
-			if mech:IsAbility("Mourningstar") then
-				--LOG("mech has right skill!")
-				return true
-			else
-				--LOG("not the right skill :(")
-			end
-		else
-			--LOG("Mech doesn't exist!!")
-		end
-	end
-	return false
-end
 ----------------------------------------------- HOOKS HANDLERS -----------------------------------------------
 
-local function GetSkillEffect(p1)
+local function Hedera_Sunrise(pawnId)
+	local pawn = Board:GetPawn(pawnId)
+	local p1 = pawn:GetSpace()
 	local ret = SkillEffect()
-	local damage = SpaceDamage(Point(0,0),0)
-	damage.iFire = 1
-	damage.sAnimation = "ExploSunbeam"
 	
-	local shine = SpaceDamage(p1,0)
-	shine.sAnimation = "ExploSunrise"
-	ret:AddDamage(shine)
-	
-	ret:AddBoardShake(0.1)
-	
-	local board_size = Board:GetSize()
-	for i = 0, board_size.x - 1 do
-		for j = 0, board_size.y - 1 do
-			if Board:IsValid(Point(i,j)) and not Board:IsBuilding(Point(i,j)) then
-				if Board:IsPawnSpace(Point(i,j)) and not Board:IsPawnTeam(Point(i,j),TEAM_PLAYER) then
-					damage.loc = Point(i,j)
-					ret:AddDamage(damage)
-					ret:AddDelay(0.1)
+	if pawn and pawn:IsAbility("Mourningstar") then
+		if Board then Board:AddAnimation(p1,"ExploSunrise",0) Board:StartShake(0.1) end-- prevent possible crash when player backs out to menu
+		--I am not sure adding a shake is necessary given the deployment also creates a board shake. perhaps this is a remnant of when you weren't able to make this exactly a deployment effect? if so then we should remove it.
+		local pawnList = extract_table(Board:GetPawns(TEAM_ANY))
+		for i = 1, #pawnList do
+			local unit = Board:GetPawn(pawnList[i])
+			local space = unit:GetSpace()
+			if unit:GetTeam() ~= TEAM_PLAYER and Board:IsValid(space) then
+				if (GetCurrentMission().ID == "Mission_FreezeBots" and unit:GetDefaultFaction() ~= FACTION_BOTS) or GetCurrentMission().ID ~= "Mission_FreezeBots" then--if you don't think this is appropriate for whatever balance reasons remove the condition, but I personally think that it should not screw you over on this mission (same line of reasoning as Void Shocker). If you want to go all the way, then don't check for the mission, since it's a massive advantage to the player to insta-kill Bots, imho. But YMMV.
+					modApi:scheduleHook(100*i, function()
+						if Game then Game:TriggerSound("/props/fire_damage") end
+						if Board then Board:AddAnimation(space,"ExploSunbeam",0) Board:SetFire(space,true) end
+					end)--100ms between each one seems to be good, but adjust it as you see fit. If you want the first one to be delayed differently, replace it with this exact expression: (i>1 and 100*i) or first_delay
+					--where first_delay is whatever value in ms you want it to be.
 				end
 			end
 		end
 	end
-	
-	return ret
-end
-
-local ApplyEffect = function(mission)
-	if IsUserPresent() and Board:GetTurn() < 1 then
-		local user_loc = GetUser():GetSpace()
-		Board:AddEffect(GetSkillEffect(user_loc))
-	end
-end
-
-local function DelayEffect()
-modApi:conditionalHook(
-	function()
-		if IsUserPresent() then
-			return Board:GetTurn() == 1
-		end
-		return false
-	end,
-	function()
-		ApplyEffect()
-	end
-)
 end
 
 ----------------------------------------------- HOOKS / EVENTS SUBSCRIPTION -----------------------------------------------
 
---this section detects the event that triggers instantly when End Turn is pressed (PARADOXICA)
-EXCL = {
-	"GetAmbience", 
-	"GetBonusStatus", 
-	"BaseUpdate", 
-	"UpdateMission", 
-	"GetCustomTile", 
-	"GetDamage", 
-	"GetTurnLimit", 
-	"BaseObjectives",
-	"UpdateObjectives",
-} 
-
-for i,v in pairs(Mission) do 
-	if type(v) == 'function' then 
-		local oldfn = v 
-		Mission[i] = function(...) 
-			if not list_contains(_G["EXCL"], i) then 
-				if i == "IsEnvironmentEffect" then
-					ApplyEffect()
-				end 
-			end 
-			return oldfn(...) 
-		end 
-	end 
-end
+modApi.events.onPawnLanded:subscribe(Hedera_Sunrise)
+-- the argument of this argument function is an integer (the ID of the Mech that has landed)

--- a/Hex Pilots Plus/mods/Thorne the Judge/scripts/hooks.lua
+++ b/Hex Pilots Plus/mods/Thorne the Judge/scripts/hooks.lua
@@ -51,7 +51,37 @@ local function Hedera_Sunrise(pawnId)
 	end
 end
 
+local function Hedera_Sunrise_Volcano(prevMission, nextMission)
+	local j = -1
+	local Thorne = nil
+	modApi:scheduleHook(3500, function()
+		if Game == nil then return end
+		for i = 0,2 do
+			local pawn = Game:GetPawn(i)
+			if pawn and pawn:IsAbility("Mourningstar") then
+				j = i
+			end
+		end
+		Thorne = Game:GetPawn(j)
+		modApi:conditionalHook(
+			function()
+				return Game == nil or (Thorne ~= nil and Thorne:GetSpace() ~= Point(-1,-1) and not Thorne:IsBusy()) or (Game:GetPawn(2):GetSpace() ~= Point(-1,-1) and not Game:GetPawn(2):IsBusy())
+			end,
+			function()
+				if Thorne ~= nil then
+				--simplify and just call the other function
+					Hedera_Sunrise(j)
+				end
+			end
+		)
+	end)
+end
+
 ----------------------------------------------- HOOKS / EVENTS SUBSCRIPTION -----------------------------------------------
 
+local function EVENT_onModsLoaded()
+	modApi:addMissionNextPhaseCreatedHook(Hedera_Sunrise_Volcano)
+end
+modApi.events.onModsLoaded:subscribe(EVENT_onModsLoaded)
 modApi.events.onPawnLanded:subscribe(Hedera_Sunrise)
 -- the argument of this argument function is an integer (the ID of the Mech that has landed)


### PR DESCRIPTION
Note that this requires the patched deployment.lua in order for it to work.

All skillEffects have been reworked as board/game commands to prevent the effect from creating an awkward delay between mechs deploying (if it isn't the last mech to be deployed)

May want to remove the Shake effect since deployment already creates a Shake (remnant of when this wasn't a deploy effect?)

Conditioned it to not burn the two Bots in Freeze and Defend the Bots mission, but you can remove that if you want, or expand it to include all Bots, however you see fit.

Delays are customisable, so go nuts.